### PR TITLE
🐛 Fix extension import for compatibility with grow v1.0.0

### DIFF
--- a/amp_dependency_injector/__init__.py
+++ b/amp_dependency_injector/__init__.py
@@ -1,1 +1,1 @@
-from amp_dependency_injector import *
+from . amp_dependency_injector import *


### PR DESCRIPTION
In grow 1 muss im Import ein Punkt vor dem Namen der Extension stehen, sonst funktioniert er nicht.
Ich habe bei fahrrad.hamburg lokal getestet ob das irgendwelche Auswirkungen auf die alten Grow Versionen hat, konnte aber keinen Fehler finden.

@matthiasrohmer kannst du bei Gelegenheit mal schauen, ob das für amp.dev auch in Ordnung ist?

**Achtung Verwechslungsgefahr:** habe den selben PR auch für das `grow-ext-inline-text-assets` Repo gestellt