### PR TITLE
🐛 Fix some python3 changes

### DIFF
--- a/amp_dependency_injector/amp_dependency_injector.py
+++ b/amp_dependency_injector/amp_dependency_injector.py
@@ -183,7 +183,7 @@ class AmpDependencyInjectorPostRenderHook(hooks.PostRenderHook):
         for dependency in dependencies:
             # TODO: Handle different versions, URL and type within VALID_DEPENDENCIES
             src = 'https://cdn.ampproject.org/v0/{}-0.1.js'.format(dependency)
-            type = 'element' if dependency is not 'amp-mustache' else 'template'
+            type = 'element' if dependency != 'amp-mustache' else 'template'
 
             tag = '<script custom-{type}="{dependency}" src="{src}" async></script>'.format(type=type, dependency=dependency, src=src)
             script_tags.append(tag)

--- a/amp_dependency_injector/amp_dependency_injector.py
+++ b/amp_dependency_injector/amp_dependency_injector.py
@@ -95,11 +95,11 @@ class AmpDependencyInjectorPostRenderHook(hooks.PostRenderHook):
 
         # Quick check if the page is really a AMP page but convert to uft-8 before
         content = content.encode('utf-8')
-        if not any(marker in content for marker in ['<html amp', '<html ⚡']):
+        if not any(marker in content for marker in [b'<html amp', b'<html ⚡']):
             return False
 
         # And has a head element
-        if '</head>' not in content:
+        if b'</head>' not in content:
             return False
 
         return True

--- a/amp_dependency_injector/amp_dependency_injector.py
+++ b/amp_dependency_injector/amp_dependency_injector.py
@@ -95,7 +95,7 @@ class AmpDependencyInjectorPostRenderHook(hooks.PostRenderHook):
 
         # Quick check if the page is really a AMP page but convert to uft-8 before
         content = content.encode('utf-8')
-        if not any(marker in content for marker in [b'<html amp', b'<html ⚡']):
+        if not any(marker in content for marker in [b'<html amp', b'<html \u26A1']):
             return False
 
         # And has a head element


### PR DESCRIPTION
Ich habe ein paar notwendige Kleinigkeiten gefixt, damit der amp-dependency-injector nachdem update auf grow 1 weiterhin funktioniert. Auch wenn der AMP-Optimizer das automatische hinzufügen der AMP-Dependencies jetzt übernimmt, brauchen wir diese extension weiterhin während des Entwickelns. Der Optimizer läuft ja nur beim builden.